### PR TITLE
Fix multi-wallet select

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -232,7 +232,10 @@ export default function LoginPage() {
                     <AuthLinker
                       isLinked
                       wallet={wallet}
-                      isActive={wallet.address === activeWallet?.address}
+                      isActive={
+                        wallet.address === activeWallet?.address &&
+                        wallet.connectedAt === activeWallet?.connectedAt
+                      }
                       setActiveWallet={setActiveWallet}
                       key={wallet.address}
                       label={formatWallet(wallet.address)}


### PR DESCRIPTION
In the active wallet display, the wallet is matched on address alone. Now, we match on both address and connection time.

Before:
<img width="326" alt="image" src="https://github.com/privy-io/auth-demo/assets/74164885/d4f03c2e-5762-4f04-b2f9-3ba3c638ece2">
After:
<img width="321" alt="image" src="https://github.com/privy-io/auth-demo/assets/74164885/eec616a9-324f-4d86-8ab0-a6819c737732">
