### PR TITLE
Display all connected wallets instead of only connected + linked accounts

### DIFF
--- a/components/auth-linker.tsx
+++ b/components/auth-linker.tsx
@@ -94,11 +94,19 @@ export default function AuthLinker({
     if (isLinked) {
       return (
         <button
-          className="button h-5 w-5 text-privy-color-foreground-2"
+          className="button group/tooltip relative flex h-5 w-5 flex-col items-center text-privy-color-foreground-2"
           onClick={unlinkAction}
           disabled={!canUnlink}
         >
           <MinusSmallIcon className="h-4 w-4" strokeWidth={2} />
+          {!canUnlink && (
+            <div className="absolute bottom-0 mb-6 hidden flex-col items-center group-hover/tooltip:flex">
+              <span className="whitespace-no-wrap relative z-10 w-[156px] rounded-md bg-privy-color-foreground p-2 text-xs leading-[1.1rem] text-privy-color-background shadow-lg">
+                This wallet is connected but not linked.
+              </span>
+              <div className="-mt-2 h-3 w-3 rotate-45 bg-privy-color-foreground"></div>
+            </div>
+          )}
         </button>
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@datadog/browser-rum": "^4.32.1",
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^2.0.12",
-        "@privy-io/react-auth": "1.26.0-beta.12",
+        "@privy-io/react-auth": "1.26.1-beta.10",
         "@privy-io/server-auth": "1.2.0",
         "@tailwindcss/forms": "^0.5.3",
         "@types/tinycolor2": "^1.4.3",
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "1.26.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.26.0-beta.12.tgz",
-      "integrity": "sha512-PGSS1I8QUIIlexHH4BTM7S3nJVZAtU91dF/bx7aZCBAyMUozu3YyhNur8MOvE0aYCTF6Z0OQ+7BimqGioTWJXQ==",
+      "version": "1.26.1-beta.10",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.26.1-beta.10.tgz",
+      "integrity": "sha512-1xLfcNt9Jp+lIhiWT8cxcN4VyWdHJeH3fY3yx/iOhEX/Es75h4KaOtsneT7YwYp0r3ecBaCXlbLBLE/fEUGd/w==",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.6.4",
         "@ethersproject/address": "^5.7.0",
@@ -9954,9 +9954,9 @@
       }
     },
     "@privy-io/react-auth": {
-      "version": "1.26.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.26.0-beta.12.tgz",
-      "integrity": "sha512-PGSS1I8QUIIlexHH4BTM7S3nJVZAtU91dF/bx7aZCBAyMUozu3YyhNur8MOvE0aYCTF6Z0OQ+7BimqGioTWJXQ==",
+      "version": "1.26.1-beta.10",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.26.1-beta.10.tgz",
+      "integrity": "sha512-1xLfcNt9Jp+lIhiWT8cxcN4VyWdHJeH3fY3yx/iOhEX/Es75h4KaOtsneT7YwYp0r3ecBaCXlbLBLE/fEUGd/w==",
       "requires": {
         "@coinbase/wallet-sdk": "^3.6.4",
         "@ethersproject/address": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@datadog/browser-rum": "^4.32.1",
     "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^2.0.12",
-    "@privy-io/react-auth": "1.26.0-beta.12",
+    "@privy-io/react-auth": "1.26.1-beta.10",
     "@privy-io/server-auth": "1.2.0",
     "@tailwindcss/forms": "^0.5.3",
     "@types/tinycolor2": "^1.4.3",

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -97,7 +97,6 @@ export default function LoginPage() {
   const linkedAccounts = user?.linkedAccounts || [];
 
   const wallets = allWallets.sort((a, b) => a.address.localeCompare(b.address));
-  console.log(activeWallet?.connectedAt);
 
   useEffect(() => {
     // if no active wallet is set, set it to the first one if available

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -230,7 +230,7 @@ export default function LoginPage() {
                   Wallets
                 </CanvasCardHeader>
                 <div className="text-sm text-privy-color-foreground-3">
-                  Whether you have one or fifteen, easily link wallets to your account.
+                  Connect and link wallets to your account.
                 </div>
                 <div className="flex flex-col gap-2">
                   {wallets.map((wallet) => (
@@ -244,7 +244,7 @@ export default function LoginPage() {
                       setActiveWallet={setActiveWallet}
                       key={wallet.address}
                       label={formatWallet(wallet.address)}
-                      canUnlink={canRemoveAccount}
+                      canUnlink={canRemoveAccount && wallet.linked}
                       unlinkAction={() => {
                         wallet.unlink();
                       }}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -97,8 +97,7 @@ export default function LoginPage() {
   const linkedAccounts = user?.linkedAccounts || [];
 
   const wallets = allWallets
-    .sort((a, b) => a.address.localeCompare(b.address))
-    .filter((w) => w.linked);
+    .sort((a, b) => a.address.localeCompare(b.address));
 
   useEffect(() => {
     // if no active wallet is set, set it to the first one if available

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -96,8 +96,8 @@ export default function LoginPage() {
 
   const linkedAccounts = user?.linkedAccounts || [];
 
-  const wallets = allWallets
-    .sort((a, b) => a.address.localeCompare(b.address));
+  const wallets = allWallets.sort((a, b) => a.address.localeCompare(b.address));
+  console.log(activeWallet?.connectedAt);
 
   useEffect(() => {
     // if no active wallet is set, set it to the first one if available
@@ -229,7 +229,7 @@ export default function LoginPage() {
                   <WalletIcon className="h-5 w-5" strokeWidth={2} />
                   Wallets
                 </CanvasCardHeader>
-                <div className="text-sm text-privy-color-foreground-3">
+                <div className="pb-1 text-sm text-privy-color-foreground-3">
                   Connect and link wallets to your account.
                 </div>
                 <div className="flex flex-col gap-2">

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -239,7 +239,8 @@ export default function LoginPage() {
                       wallet={wallet}
                       isActive={
                         wallet.address === activeWallet?.address &&
-                        wallet.connectedAt === activeWallet?.connectedAt
+                        wallet.connectorType === activeWallet?.connectorType &&
+                        wallet.walletClientType === activeWallet?.walletClientType
                       }
                       setActiveWallet={setActiveWallet}
                       key={wallet.address}


### PR DESCRIPTION
Probably don't land as-is, but the idea is that we should display all connected wallets (all wallets in the `wallets` array).

TODOs:
- Update copy format so it's not orphaning a word on the new line (maybe tweak the spacing so it's all on one line?)
- Add some signal to the user that the wallet is linked vs. only connected (maybe a little "linked" text after the address?)
- Make it clear why unlinking is disabled, i.e. because it is not linked or there is only one account (maybe hover-over text?)