### PR TITLE
Fix theming storage, linked wallet list, no-create privy wallet on login

### DIFF
--- a/components/auth-linker.tsx
+++ b/components/auth-linker.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
-import {MinusSmallIcon, PlusSmallIcon} from '@heroicons/react/24/outline';
+import {MinusSmallIcon, PlusSmallIcon, LinkIcon} from '@heroicons/react/24/outline';
 import {formatWallet, getHumanReadableWalletType} from '../lib/utils';
-import type {ConnectedWallet} from '@privy-io/react-auth';
+import type {WalletWithMetadata} from '@privy-io/react-auth';
 import type React from 'react';
 import Image from 'next/image';
 
@@ -16,11 +16,14 @@ export default function AuthLinker({
   setActiveWallet,
   unlinkAction,
   socialIcon,
+  walletConnectorName,
+  isConnected,
+  connectAction,
   className,
 }: {
-  wallet?: ConnectedWallet;
+  wallet?: WalletWithMetadata;
   isActive?: boolean;
-  setActiveWallet?: (wallet: ConnectedWallet) => void;
+  setActiveWallet?: (wallet: WalletWithMetadata) => void;
   isLinked: boolean;
   linkedLabel?: string | null;
   linkAction: () => void;
@@ -28,11 +31,14 @@ export default function AuthLinker({
   canUnlink: boolean;
   label?: string;
   socialIcon?: JSX.Element;
+  walletConnectorName?: string;
+  isConnected?: boolean;
+  connectAction?: (address: string) => void;
   className?: string;
 }) {
-  const isEmbeddedWallet = wallet?.walletClientType === 'privy';
+  const isEmbeddedWallet = wallet?.walletClient === 'privy';
 
-  const getWalletType = (wallet: ConnectedWallet) => {
+  const getWalletType = (wallet: WalletWithMetadata) => {
     if (isEmbeddedWallet) {
       return {
         address: formatWallet(wallet.address),
@@ -55,24 +61,50 @@ export default function AuthLinker({
       address: formatWallet(wallet.address),
       icon: (
         <div className="h-[1.125rem] w-[1.125rem] shrink-0 grow-0 overflow-hidden rounded-[0.25rem]">
-          <Image
-            src={`/wallet-icons/${wallet.walletClientType}.svg`}
-            height={20}
-            width={20}
-            className="h-full w-full object-cover"
-            alt={getHumanReadableWalletType(wallet.walletClientType as any)}
-          />
+          {walletConnectorName ? (
+            <Image
+              src={`/wallet-icons/${walletConnectorName}.svg`}
+              height={20}
+              width={20}
+              className="h-full w-full object-cover"
+              alt={getHumanReadableWalletType(walletConnectorName as any)}
+            />
+          ) : (
+            <LinkIcon className="h-4 w-4 text-privy-color-foreground" strokeWidth={2} />
+          )}
         </div>
       ),
-      description: `${getHumanReadableWalletType(wallet.walletClientType as any)}`,
+      description: `${getHumanReadableWalletType(walletConnectorName as any)}`,
     };
   };
 
-  const SetActiveButton = ({wallet, isActive}: {wallet?: ConnectedWallet; isActive?: boolean}) => {
+  const SetActiveButton = ({
+    wallet,
+    isActive,
+  }: {
+    wallet?: WalletWithMetadata;
+    isActive?: boolean;
+  }) => {
     if (wallet && isActive) {
       return (
         <div className="flex h-5 items-center justify-center rounded-md bg-gradient-to-r from-privy-color-accent to-red-300 px-1 text-xs font-medium text-white">
           Active
+        </div>
+      );
+    }
+    if (wallet && !isConnected) {
+      return (
+        <div
+          className="group/tooltip button h-5 shrink-0 grow-0 translate-x-2 cursor-pointer px-1 text-xs text-privy-color-foreground-2 opacity-0 group-hover:translate-x-0 group-hover:opacity-100"
+          onClick={() => connectAction?.(wallet.address)}
+        >
+          Connect
+          <div className="absolute bottom-0 mb-6 hidden flex-col items-center group-hover/tooltip:flex">
+            <span className="whitespace-no-wrap relative z-10 w-[156px] rounded-md bg-privy-color-foreground p-2 text-xs leading-[1.1rem] text-privy-color-background shadow-lg">
+              Re-connect this wallet to use it.
+            </span>
+            <div className="-mt-2 h-3 w-3 rotate-45 bg-privy-color-foreground"></div>
+          </div>
         </div>
       );
     }

--- a/lib/hooks/usePrivyConfig.ts
+++ b/lib/hooks/usePrivyConfig.ts
@@ -10,7 +10,7 @@ export type PrivyConfigContextType = {
 
 export const privyLogo = 'https://pub-dc971f65d0aa41d18c1839f8ab426dcb.r2.dev/privy.png';
 export const privyLogoDark = 'https://pub-dc971f65d0aa41d18c1839f8ab426dcb.r2.dev/privy-dark.png';
-export const PRIVY_APPEARANCE_STORAGE_KEY = 'privy-appearance';
+export const PRIVY_STORAGE_KEY = 'privy-config';
 
 export const defaultIndexConfig: PrivyDemoConfig = {
   appearance: {
@@ -32,7 +32,6 @@ export const defaultDashboardConfig: PrivyDemoConfig = {
     inDialog: true,
     inParentNodeId: null,
   },
-  createPrivyWalletOnLogin: true,
 };
 
 const PrivyConfigContext = createContext<PrivyConfigContextType>({config: {}});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import {useCallback, useMemo, useState} from 'react';
 import PrivyConfigContext, {
   defaultIndexConfig,
   PrivyConfigContextType,
-  PRIVY_APPEARANCE_STORAGE_KEY,
+  PRIVY_STORAGE_KEY,
 } from '../lib/hooks/usePrivyConfig';
 
 function MyApp({Component, pageProps}: AppProps) {
@@ -16,10 +16,7 @@ function MyApp({Component, pageProps}: AppProps) {
 
   const setConfigWithAppearanceStorage = useCallback(
     (newConfig: PrivyConfigContextType['config']) => {
-      window.localStorage.setItem(
-        PRIVY_APPEARANCE_STORAGE_KEY,
-        JSON.stringify(newConfig.appearance),
-      );
+      window.localStorage.setItem(PRIVY_STORAGE_KEY, JSON.stringify(newConfig));
       return setConfig(newConfig);
     },
     [setConfig],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,7 +47,7 @@ function MyApp({Component, pageProps}: AppProps) {
               setDatadogUser(user);
             }}
             config={config}
-            createPrivyWalletOnLogin={config.createPrivyWalletOnLogin}
+            createPrivyWalletOnLogin={config.createPrivyWalletOnLogin ?? false}
           >
             <Component {...pageProps} />
           </PrivyProvider>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -51,6 +51,7 @@ export default function LoginPage() {
 
   const {setConfig} = useContext(PrivyConfigContext);
 
+  // set initial config, first checking for stored config, then falling back to default
   useEffect(() => {
     const storedConfigRaw = window.localStorage.getItem(PRIVY_STORAGE_KEY);
     const storedConfig = storedConfigRaw ? JSON.parse(storedConfigRaw) : null;
@@ -98,11 +99,10 @@ export default function LoginPage() {
   }, [ready, authenticated, router]);
 
   const linkedAccounts = user?.linkedAccounts || [];
-
   const wallets = linkedAccounts.filter((a) => a.type === 'wallet') as WalletWithMetadata[];
-  const linkedAndConnectedWallets = wallets.filter((w) =>
-    connectedWallets.some((cw) => cw.address === w.address),
-  );
+  const linkedAndConnectedWallets = wallets
+    .filter((w) => connectedWallets.some((cw) => cw.address === w.address))
+    .sort((a, b) => b.verifiedAt.toLocaleString().localeCompare(a.verifiedAt.toLocaleString()));
 
   useEffect(() => {
     // if no active wallet is set, set it to the first one if available

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -60,11 +60,11 @@ export default function LoginPage() {
       appearance: storedConfig?.appearance
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,
-      createPrivyWalletOnLogin: storedConfig?.createPrivyWalletOnLogin
-        ? storedConfig.createPrivyWalletOnLogin
-        : defaultIndexConfig.createPrivyWalletOnLogin,
+      createPrivyWalletOnLogin:
+        storedConfig?.createPrivyWalletOnLogin ?? defaultIndexConfig.createPrivyWalletOnLogin,
     });
-  }, [setConfig]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     ready,

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -60,6 +60,9 @@ export default function LoginPage() {
       appearance: storedConfig?.appearance
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,
+      createPrivyWalletOnLogin: storedConfig?.createPrivyWalletOnLogin
+        ? storedConfig.createPrivyWalletOnLogin
+        : defaultIndexConfig.createPrivyWalletOnLogin,
     });
   }, [setConfig]);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
       appearance: storedConfig?.appearance
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,
-      createPrivyWalletOnLogin: storedConfig.createPrivyWalletOnLogin
+      createPrivyWalletOnLogin: storedConfig?.createPrivyWalletOnLogin
         ? storedConfig.createPrivyWalletOnLogin
         : defaultIndexConfig.createPrivyWalletOnLogin,
     });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,7 +38,9 @@ export default function LoginPage() {
   useEffect(() => {
     setConfig?.({
       ...config,
-      appearance: storedConfig.appearance ? storedConfig.appearance : defaultIndexConfig.appearance,
+      appearance: storedConfig?.appearance
+        ? storedConfig.appearance
+        : defaultIndexConfig.appearance,
       _render: isMobile ? defaultDashboardConfig._render : defaultIndexConfig._render,
     });
     // ensure that the modal is open on desktop
@@ -60,13 +62,15 @@ export default function LoginPage() {
     setConfig?.({
       ...(oauthProvider ? defaultDashboardConfig : defaultIndexConfig),
       _render: isMobileOnLoad ? defaultDashboardConfig._render : defaultIndexConfig._render,
-      appearance: storedConfig.appearance ? storedConfig.appearance : defaultIndexConfig.appearance,
+      appearance: storedConfig?.appearance
+        ? storedConfig.appearance
+        : defaultIndexConfig.appearance,
       createPrivyWalletOnLogin: storedConfig.createPrivyWalletOnLogin
         ? storedConfig.createPrivyWalletOnLogin
         : defaultIndexConfig.createPrivyWalletOnLogin,
     });
 
-    if (!isMobileOnLoad) {
+    if (!isMobileOnLoad && !authenticated) {
       login();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,9 +42,11 @@ export default function LoginPage() {
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,
       _render: isMobile ? defaultDashboardConfig._render : defaultIndexConfig._render,
+      createPrivyWalletOnLogin:
+        storedConfig?.createPrivyWalletOnLogin ?? defaultIndexConfig.createPrivyWalletOnLogin,
     });
     // ensure that the modal is open on desktop
-    if (!isMobile) {
+    if (!isMobile && !authenticated) {
       login();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -65,9 +67,8 @@ export default function LoginPage() {
       appearance: storedConfig?.appearance
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,
-      createPrivyWalletOnLogin: storedConfig?.createPrivyWalletOnLogin
-        ? storedConfig.createPrivyWalletOnLogin
-        : defaultIndexConfig.createPrivyWalletOnLogin,
+      createPrivyWalletOnLogin:
+        storedConfig?.createPrivyWalletOnLogin ?? defaultIndexConfig.createPrivyWalletOnLogin,
     });
 
     if (!isMobileOnLoad && !authenticated) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,7 @@ import {useContext, useEffect, useState} from 'react';
 import PrivyConfigContext, {
   defaultDashboardConfig,
   defaultIndexConfig,
-  PRIVY_APPEARANCE_STORAGE_KEY,
+  PRIVY_STORAGE_KEY,
 } from '../lib/hooks/usePrivyConfig';
 import useMediaQuery from '../lib/hooks/useMediaQuery';
 
@@ -30,11 +30,15 @@ export default function LoginPage() {
   const {login, ready, authenticated} = usePrivy();
   const {config, setConfig} = useContext(PrivyConfigContext);
   const [copied, setCopied] = useState(false);
+  const storedConfigRaw =
+    typeof window === 'undefined' ? null : window.localStorage.getItem(PRIVY_STORAGE_KEY);
+  const storedConfig = storedConfigRaw ? JSON.parse(storedConfigRaw) : null;
 
   const isMobile = useMediaQuery(mobileQuery);
   useEffect(() => {
     setConfig?.({
       ...config,
+      appearance: storedConfig.appearance ? storedConfig.appearance : defaultIndexConfig.appearance,
       _render: isMobile ? defaultDashboardConfig._render : defaultIndexConfig._render,
     });
     // ensure that the modal is open on desktop
@@ -56,9 +60,10 @@ export default function LoginPage() {
     setConfig?.({
       ...(oauthProvider ? defaultDashboardConfig : defaultIndexConfig),
       _render: isMobileOnLoad ? defaultDashboardConfig._render : defaultIndexConfig._render,
-      appearance: window.localStorage.getItem(PRIVY_APPEARANCE_STORAGE_KEY)
-        ? JSON.parse(window.localStorage.getItem(PRIVY_APPEARANCE_STORAGE_KEY)!)
-        : defaultIndexConfig.appearance,
+      appearance: storedConfig.appearance ? storedConfig.appearance : defaultIndexConfig.appearance,
+      createPrivyWalletOnLogin: storedConfig.createPrivyWalletOnLogin
+        ? storedConfig.createPrivyWalletOnLogin
+        : defaultIndexConfig.createPrivyWalletOnLogin,
     });
 
     if (!isMobileOnLoad) {
@@ -143,14 +148,9 @@ export default function LoginPage() {
                       const providerCode = `<PrivyProvider createPrivyWalletOnLogin={${createPrivyWalletOnLogin}} config={${JSON.stringify(
                         rest,
                       )}}>{children}</PrivyProvider>`;
-                      navigator.clipboard
-                        .writeText(providerCode)
-                        .then(() => {
-                          console.log('Text copied to clipboard');
-                        })
-                        .catch((error) => {
-                          console.error('Failed to copy text to clipboard:', error);
-                        });
+                      navigator.clipboard.writeText(providerCode).catch((error) => {
+                        console.error('Failed to copy text to clipboard:', error);
+                      });
                       setCopied(true);
                       setTimeout(() => {
                         setCopied(false);


### PR DESCRIPTION
- moves back to only showing linked wallets
- enables a flow for re-connecting linked wallets that are not connected 
- sets the initial active wallet to the last linked (and connected)
- fixes an issue where occasionally the modal would pop up in the dashboard
- fixes create-privy-wallet automatically = false
- fixes theme grabbing via local storage