### PR TITLE
fix: errant config

### DIFF
--- a/components/canvas-sidebar-auth-config.tsx
+++ b/components/canvas-sidebar-auth-config.tsx
@@ -64,7 +64,13 @@ function StaticColorPicker({
 
 type AuthConfiguration = 'wallets' | 'socials';
 
-export default function CanvasSidebarAuthConfig({className}: {className?: string}) {
+export default function CanvasSidebarAuthConfig({
+  readyToSetTheme,
+  className,
+}: {
+  readyToSetTheme: boolean;
+  className?: string;
+}) {
   const [draggedConfig, setDraggedConfig] = useState<AuthConfiguration | null>(null);
   const {config, setConfig} = useContext(PrivyConfigContext);
   const [defaultConfigStyles, setDefaultConfigStyles] = useState<string>(
@@ -73,6 +79,9 @@ export default function CanvasSidebarAuthConfig({className}: {className?: string
   const [userLogoUrl, setUserLogoUrl] = useState<string>('');
 
   useEffect(() => {
+    if (!readyToSetTheme) {
+      return;
+    }
     setConfig?.({
       ...config,
       appearance: {
@@ -81,7 +90,7 @@ export default function CanvasSidebarAuthConfig({className}: {className?: string
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userLogoUrl]);
+  }, [userLogoUrl, readyToSetTheme]);
 
   const handleDrag = (e: React.DragEvent<HTMLDivElement>, config: AuthConfiguration) => {
     setDraggedConfig(config);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,9 +33,13 @@ export default function LoginPage() {
   const storedConfigRaw =
     typeof window === 'undefined' ? null : window.localStorage.getItem(PRIVY_STORAGE_KEY);
   const storedConfig = storedConfigRaw ? JSON.parse(storedConfigRaw) : null;
+  const [readyToSetTheme, setReadyToSetTheme] = useState(false);
 
   const isMobile = useMediaQuery(mobileQuery);
   useEffect(() => {
+    if (!ready || authenticated) {
+      return;
+    }
     setConfig?.({
       ...config,
       appearance: storedConfig?.appearance
@@ -46,14 +50,19 @@ export default function LoginPage() {
         storedConfig?.createPrivyWalletOnLogin ?? defaultIndexConfig.createPrivyWalletOnLogin,
     });
     // ensure that the modal is open on desktop
-    if (!isMobile && !authenticated) {
+    if (!isMobile) {
       login();
     }
+    setReadyToSetTheme(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMobile]);
+  }, [isMobile, ready, authenticated]);
 
   useEffect(() => {
+    if (!ready || authenticated) {
+      return;
+    }
     const isMobileOnLoad = window.matchMedia(mobileQuery).matches;
+
     // there is an issue with applying the dashboard config (render as modal)
     // _after_ loading the dashboard page, where the changing from in-line to modal
     // rendering will re-trigger the oauth process (since that's an effect on the oauth
@@ -71,11 +80,12 @@ export default function LoginPage() {
         storedConfig?.createPrivyWalletOnLogin ?? defaultIndexConfig.createPrivyWalletOnLogin,
     });
 
-    if (!isMobileOnLoad && !authenticated) {
+    if (!isMobileOnLoad) {
       login();
     }
+    setReadyToSetTheme(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ready, authenticated]);
 
   if (!ready) {
     return <Loading />;
@@ -100,7 +110,7 @@ export default function LoginPage() {
           Launch Privy
         </button>
         <CanvasContainer>
-          <CanvasSidebarAuthConfig className="flex flex-col" />
+          <CanvasSidebarAuthConfig readyToSetTheme={readyToSetTheme} className="flex flex-col" />
           {/* start: canvas-panel */}
           <Canvas className="md:pl-20 md:pr-8">
             {/* start: modal-column */}


### PR DESCRIPTION
I noticed that there are still cases when:
- the login modal will pop up upon loading the dashboard once authenticated 
- the wallet auth will pop up a signing screen after the user has already authenticated

This should fix that. 

It introduces a slight stutter of the theme upon load, but IMO it's better than the alternative. 

This whole thing has gotten a little out of hand in complexity due to the switching rendering modes, local storage, and privy authenticated state redirect being a race condition. I don't think it's worth refactoring now