### PR TITLE
fix: dashboard rendering

### DIFF
--- a/lib/hooks/usePrivyConfig.ts
+++ b/lib/hooks/usePrivyConfig.ts
@@ -29,6 +29,10 @@ export const defaultIndexConfig: PrivyClientConfig = {
 };
 
 export const defaultDashboardConfig: PrivyClientConfig = {
+  embeddedWallets: {
+    createOnLogin: 'users-without-wallets',
+    requireUserPasswordOnCreate: false,
+  },
   _render: {
     inDialog: true,
     inParentNodeId: null,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,16 +9,20 @@ import PrivyConfigContext, {
   defaultIndexConfig,
   PrivyConfigContextType,
   PRIVY_STORAGE_KEY,
+  defaultDashboardConfig,
 } from '../lib/hooks/usePrivyConfig';
 
-function MyApp({Component, pageProps}: AppProps) {
+function MyApp({Component, pageProps, router}: AppProps) {
   const [config, setConfig] = useState<PrivyConfigContextType['config']>(() => {
     // Pull out the appearance from local storage if it exists
     const storedConfigRaw =
       typeof window === 'undefined' ? null : window.localStorage.getItem(PRIVY_STORAGE_KEY);
     const storedConfig = storedConfigRaw ? JSON.parse(storedConfigRaw) : null;
+    const defaultConfig = router?.route?.includes('dashboard')
+      ? defaultDashboardConfig
+      : defaultIndexConfig;
     return {
-      ...defaultIndexConfig,
+      ...defaultConfig,
       appearance: storedConfig?.appearance
         ? storedConfig.appearance
         : defaultIndexConfig.appearance,

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -41,7 +41,7 @@ import PrivyBlobIcon from '../components/icons/outline/privy-blob';
 import GitHubIcon from '../components/icons/social/github';
 import AppleIcon from '../components/icons/social/apple';
 
-export default function LoginPage() {
+export default function DashboardPage() {
   const router = useRouter();
   const [signLoading, setSignLoading] = useState(false);
   const [signSuccess, setSignSuccess] = useState(false);


### PR DESCRIPTION
There's a current issue where server / client state gets mismatched, and the dashboard renders the modal as inline instead of modal. This doesn't fix that issue directly, but instead ensures the server starts with the right config state for the route. Which is good.