### PR TITLE
Allow renovate to automerge from branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "rangeStrategy": "pin",


### PR DESCRIPTION
I was wondering why auth-demo keeps falling behind - it's required to create a PR for each change. We should mirror the [internal-auth-demo](https://github.com/privy-io/internal-auth-demo/blob/3c01b787f190299756f33b12e83e489163c23bc3/renovate.json#L16), which allows automerge without creating a PR, so long as checks pass and it's not a breaking change version.