### PR TITLE
Update typescript to match version used in react-auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier-plugin-tailwindcss": "^0.1.13",
         "tailwindcss": "^3.1.2",
         "ts-node": "^10.9.1",
-        "typescript": "^4.7.2"
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">=18.0.0 <19.0.0",
@@ -7931,9 +7931,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14418,9 +14418,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "devOptional": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "prettier-plugin-tailwindcss": "^0.1.13",
     "tailwindcss": "^3.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.2"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
### Description
Previously this was causing [type errors](https://vercel.com/horkos/auth-demo/C9YNTULAELv3DaGJHXnFzmiDAnrZ) when using hidden/internal `react-auth` apis after bumping version to `v1.40.0`