### PR TITLE
Fix toggle orientation

### DIFF
--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -20,15 +20,15 @@ export default function Toggle({
       <div
         className={`relative h-[0.875rem] w-7 cursor-pointer select-none rounded-full transition-all duration-300 ease-in-out ${
           checked
-            ? 'justify-start bg-privy-color-accent'
-            : 'justify-end bg-privy-color-foreground-4'
+            ? 'justify-end bg-privy-color-accent'
+            : 'justify-start bg-privy-color-foreground-4'
         }`}
       >
         <div
           className={`toggle-checkbox absolute top-1/2 m-0 block h-[0.625rem] w-[0.625rem] -translate-y-1/2 rounded-full p-0 transition-all duration-300 ease-in-out ${
             checked
-              ? 'left-0.5 right-auto bg-privy-color-background'
-              : 'left-[calc(100%-0.75rem)] bg-privy-color-foreground-3'
+              ? 'left-[calc(100%-0.75rem)] bg-privy-color-background'
+              : 'left-0.5 right-auto bg-privy-color-foreground-3'
           }`}
         />
       </div>


### PR DESCRIPTION
Had my last dance with the backwards toggles

**Before (this is _on_)**
<img width="378" alt="Screenshot 2023-10-05 at 12 54 00 PM" src="https://github.com/privy-io/auth-demo/assets/1669563/7fa23979-119d-48a5-a4a0-bf5276aefa72">

**After**

https://github.com/privy-io/auth-demo/assets/1669563/ce7da093-6d94-4154-af43-7c70516374cc

